### PR TITLE
Spelling Fixes for Leather Goddesses of Phobos

### DIFF
--- a/mars.zil
+++ b/mars.zil
@@ -1650,7 +1650,7 @@ an opening between the dunes leads west.")
       (DESC "Canalview Mall")
       (LDESC
 "As with all Martian civilization, this once-fashionable shopping center has
-fallen upon hard times; the only store to have endured the fifteen-millenia
+fallen upon hard times; the only store to have endured the fifteen-millennia
 recession lies to the south. The canal is still as visible as it was when
 scheming marketeers misnamed the mall generations ago -- in other words, not
 at all. A path leads east, and a dune to the west seems mountable.")

--- a/mars.zil
+++ b/mars.zil
@@ -3669,7 +3669,7 @@ nothing a tough g">
       (IN ROOMS)
       (DESC "Allusion Room")
       (LDESC
-"A solitary black circle is the only break in an vaste expanse of whiteness
+"A solitary black circle is the only break in an vast expanse of whiteness
 extending to the horizon. Like a dark speck in a sea of white, or a huge piece
 of typing paper with but a single period typed upon it, this black circle seems
 to have been placed here entirely as an opportunity for some silly literary


### PR DESCRIPTION
These are the spelling fixes for Leather Goddesses of Phobos from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.

NB: The same fixes, and more, also apply to the Solid Gold version. However, the leathergoddesses-invclues does not actually contain the Solid Gold version at the time of this writing.