### PR TITLE
Use fixed font for the word puzzle, as in mac-r59 and the Solid Gold version

### DIFF
--- a/phobos.zil
+++ b/phobos.zil
@@ -591,17 +591,25 @@ writing on it.")
 	(ADJECTIVE DISCARDED CRUMPLED)
 	(FLAGS TAKEBIT BURNBIT READBIT)
 	(SIZE 2)
-	(TEXT
-"There's a seemingly meaningless matrix of letters on the paper:|
-   HESOHREBBUR|
+	(ACTION SCRAP-OF-PAPER-F)>
+
+<ROUTINE SCRAP-OF-PAPER-F ()
+	 <COND (<VERB? READ>
+		<TELL
+"There's a seemingly meaningless matrix of letters on the paper:" CR>
+		<PUT 0 8 <BOR <GET 0 8> 2>> ;"turns on fixed spacing for Mac"
+		<TELL
+;"after removing all the letters from all the words on the parts list, the
+remaining letters spell HISSING FRIGHTENS FLY TRAPS"
+"   HESOHREBBUR|
    ILSSSIPNGEF|
    RGIUGHTHDEN|
    SNKOOBENOHP|
    FALYTMERATP|
    SHEADLIGHTO|
-   SLLABNOTTOC"
-;"after removing all the letters from all the words on the parts list, the
-remaining letters spell HISSING FRIGHTENS FLY TRAPS")>
+   SLLABNOTTOC|">
+		<PUT 0 8 <BAND <GET 0 8> -3>> ;"turns off fixed spacing"
+		<RTRUE>)>>
 
 <GLOBAL HOLE-OPEN <>>
 


### PR DESCRIPTION
This is the only difference between the r59 and mac-r59 source code. (Though the mac-r59 version was missing a newline at the end of the puzzle text, so the change is more like the Solid Gold version.)